### PR TITLE
Only access cookies on www.coursera.org

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,5 @@
   "manifest_version": 2,
   "name": "Coursera authentication helper",
   "version": "1.0",
-  "permissions": ["cookies","https://*.coursera.org/","clipboardWrite"]
+  "permissions": ["cookies","https://www.coursera.org/","clipboardWrite"]
 }


### PR DESCRIPTION
Google Chrome Store threatened to remove the extension. Hope this resolves it.